### PR TITLE
changing series field of citation.tsv back to non-multiple because of…

### DIFF
--- a/citation.tsv
+++ b/citation.tsv
@@ -69,7 +69,7 @@
 	dateOfCollectionStart	Start	Date when the data collection started.	YYYY-MM-DD	date	65	#NAME: #VALUE 	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	dateOfCollection	citation
 	dateOfCollectionEnd	End	Date when the data collection ended.	YYYY-MM-DD	date	66	#NAME: #VALUE 	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	dateOfCollection	citation
 	kindOfData	Kind of Data	Type of data included in the file: survey data, census/enumeration data, aggregate data, clinical data, event/transaction data, program source code, machine-readable text, administrative records data, experimental data, psychological test, textual data, coded textual, coded documents, time budget diaries, observation data/ratings, process-produced data, or other.		text	67		TRUE	FALSE	TRUE	TRUE	FALSE	FALSE		citation	http://rdf-vocabulary.ddialliance.org/discovery#kindOfData
-	series	Series	Information about the Dataset series.		none	68	:	FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation
+	series	Series	Information about the Dataset series.		none	68	:	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation
 	seriesName	Name	Name of the dataset series to which the Dataset belongs.		text	69	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	series	citation
 	seriesInformation	Information	History of the series and summary of those features that apply to the series as a whole.		textbox	70	#VALUE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	series	citation
 	software	Software	Information about the software used to generate the Dataset.		none	71	,	FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	https://www.w3.org/TR/prov-o/#wasGeneratedBy


### PR DESCRIPTION
… OpenAIRE-Export Bug

The OpenAIRE-Export of Dataverse expects the field Series to be a Single-Compound
(see [OpenAIREExportUtil.java](https://github.com/IQSS/dataverse/blob/v5.9/src/main/java/edu/harvard/iq/dataverse/export/openaire/OpenAireExportUtil.java) lines 1268 - 1274)
```
if ("citation".equals(key)) {
    for (FieldDTO fieldDTO : value.getFields()) {
        if (DatasetFieldConstant.series.equals(fieldDTO.getTypeName())) {
            // String seriesName = null;
            String seriesInformation = null;
 
            Set<FieldDTO> fieldDTOs = fieldDTO.getSingleCompound();
```
In our citation.tsv the series field is a multiple compound (as a workaround on bug [#8860](https://github.com/IQSS/dataverse/issues/8860)). In expectance of a fix of the bug (and after the immediate necessity to change the series field with the help of the edit endpoint), it seems more promising to change the TSV configuration of the citation field back to single instead of fixing the bug by changing the OpenAIRE-Export Code.

Tested on DemoDaRUS by 
`curl http://localhost:8080/api/admin/datasetfield/load -H "Content-type: text/tab-separated-values" -X POST --upload-file citation.tsv
`