### PR TITLE
merged upstream changes v5.12

### DIFF
--- a/citation.tsv
+++ b/citation.tsv
@@ -1,93 +1,93 @@
-#metadataBlock	name	dataverseAlias	displayName	blockURI											
-	citation		Citation Metadata	https://dataverse.org/schema/citation/											
+#metadataBlock	name	dataverseAlias	displayName	blockURI												
+	citation		Citation Metadata	https://dataverse.org/schema/citation/												
 #datasetField	name	title	description	watermark	 fieldType	displayOrder	displayFormat	advancedSearchField	allowControlledVocabulary	allowmultiples	facetable	displayoncreate	required	parent	metadatablock_id	termURI
-	title	Title	Full title by which the Dataset is known.	Enter title...	text	0		TRUE	FALSE	FALSE	FALSE	TRUE	TRUE		citation	http://purl.org/dc/terms/title
-	subtitle	Subtitle	A secondary title used to amplify or state certain limitations on the main title.		text	1		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation
-	alternativeTitle	Alternative Title	A title by which the work is commonly referred, or an abbreviation of the title.		text	2		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation	http://purl.org/dc/terms/alternative
-	alternativeURL	Alternative URL	A URL where the dataset can be viewed, such as a personal or project website.  	Enter full URL, starting with http://	url	3	<a href="#VALUE" target="_blank">#VALUE</a>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation	https://schema.org/distribution
-	otherId	Other ID	Another unique identifier that identifies this Dataset (e.g., producer's or another repository's number).		none	4	:	FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation
-	otherIdAgency	Agency	Name of agency which generated this identifier.		text	5	#VALUE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	otherId	citation
-	otherIdValue	Identifier	Other identifier that corresponds to this Dataset.		text	6	#VALUE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	otherId	citation
-	author	Author	The person(s), corporate body(ies), or agency(ies) responsible for creating the work.		none	7		FALSE	FALSE	TRUE	FALSE	TRUE	TRUE		citation	http://purl.org/dc/terms/creator
-	authorName	Name	The author's Family Name, Given Name or the name of the organization responsible for this Dataset.	FamilyName, GivenName or Organization	text	8	#VALUE	TRUE	FALSE	FALSE	TRUE	TRUE	TRUE	author	citation
-	authorAffiliation	Affiliation	The organization with which the author is affiliated.		text	9	(#VALUE)	TRUE	FALSE	FALSE	TRUE	TRUE	FALSE	author	citation
-	authorIdentifierScheme	Identifier Scheme	Name of the identifier scheme (ORCID, ISNI).		text	10	- #VALUE:	FALSE	TRUE	FALSE	FALSE	TRUE	FALSE	author	citation	http://purl.org/spar/datacite/AgentIdentifierScheme
-	authorIdentifier	Identifier	Uniquely identifies an individual author or organization, according to various schemes.		text	11	#VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	author	citation	http://purl.org/spar/datacite/AgentIdentifier
-	datasetContact	Contact	The contact(s) for this Dataset.		none	12		FALSE	FALSE	TRUE	FALSE	TRUE	TRUE		citation
-	datasetContactName	Name	The contact's Family Name, Given Name or the name of the organization.	FamilyName, GivenName or Organization	text	13	#VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	datasetContact	citation
-	datasetContactAffiliation	Affiliation	The organization with which the contact is affiliated.		text	14	(#VALUE)	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	datasetContact	citation
-	datasetContactEmail	E-mail	The e-mail address(es) of the contact(s) for the Dataset. This will not be displayed.		email	15	#EMAIL	FALSE	FALSE	FALSE	FALSE	TRUE	TRUE	datasetContact	citation
-	dsDescription	Description	A summary describing the purpose, nature, and scope of the Dataset.		none	16		FALSE	FALSE	TRUE	FALSE	TRUE	TRUE		citation	
-	dsDescriptionValue	Text	A summary describing the purpose, nature, and scope of the Dataset.		textbox	17	#VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	TRUE	dsDescription	citation
-	dsDescriptionDate	Date	In cases where a Dataset contains more than one description (for example, one might be supplied by the data producer and another prepared by the data repository where the data are deposited), the date attribute is used to distinguish between the two descriptions. The date attribute follows the ISO convention of YYYY-MM-DD.	YYYY-MM-DD	date	18	(#VALUE)	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	dsDescription	citation
-	subject	Subject	Domain-specific Subject Categories that are topically relevant to the Dataset.		text	19		TRUE	TRUE	TRUE	TRUE	TRUE	TRUE		citation	http://purl.org/dc/terms/subject
-	keyword	Keyword	Key terms that describe important aspects of the Dataset.		none	20		FALSE	FALSE	TRUE	FALSE	TRUE	FALSE		citation
-	keywordValue	Term	Key terms that describe important aspects of the Dataset. Can be used for building keyword indexes and for classification and retrieval purposes. A controlled vocabulary can be employed. The vocab attribute is provided for specification of the controlled vocabulary in use, such as LCSH, MeSH, or others. The vocabURI attribute specifies the location for the full controlled vocabulary.		text	21	#VALUE	TRUE	FALSE	FALSE	TRUE	TRUE	FALSE	keyword	citation
-	keywordVocabulary	Vocabulary	For the specification of the keyword controlled vocabulary in use, such as LCSH, MeSH, or others.		text	22	(#VALUE)	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	keyword	citation
-	keywordVocabularyURI	Vocabulary URL	Keyword vocabulary URL points to the web presence that describes the keyword vocabulary, if appropriate. Enter an absolute URL where the keyword vocabulary web site is found, such as http://www.my.org.	Enter full URL, starting with http://	url	23	<a href="#VALUE" target="_blank" rel="noopener">#VALUE</a>	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	keyword	citation
-	topicClassification	Topic Classification	The classification field indicates the broad important topic(s) and subjects that the data cover. Library of Congress subject terms may be used here.  		none	24		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation
-	topicClassValue	Term	Topic or Subject term that is relevant to this Dataset.		text	25	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	topicClassification	citation
-	topicClassVocab	Vocabulary	Provided for specification of the controlled vocabulary in use, e.g., LCSH, MeSH, etc.		text	26	(#VALUE)	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	topicClassification	citation
-	topicClassVocabURI	Vocabulary URL	Specifies the URL location for the full controlled vocabulary.	Enter full URL, starting with http://	url	27	<a href="#VALUE" target="_blank" rel="noopener">#VALUE</a>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	topicClassification	citation
-	publication	Related Publication	Publications that use the data from this Dataset. The full list of Related Publications will be displayed on the metadata tab.		none	28		FALSE	FALSE	TRUE	FALSE	TRUE	FALSE		citation	http://purl.org/dc/terms/isReferencedBy
-	publicationCitation	Citation	The full bibliographic citation for this related publication.		textbox	29	#VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	publication	citation	http://purl.org/dc/terms/bibliographicCitation
-	publicationIDType	ID Type	The type of digital identifier used for this publication (e.g., Digital Object Identifier (DOI)).		text	30	#VALUE: 	TRUE	TRUE	FALSE	FALSE	TRUE	FALSE	publication	citation	http://purl.org/spar/datacite/ResourceIdentifierScheme
-	publicationIDNumber	ID Number	The identifier for the selected ID type.		text	31	#VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	publication	citation	http://purl.org/spar/datacite/ResourceIdentifier
-	publicationURL	URL	Link to the publication web page (e.g., journal article page, archive record page, or other).	Enter full URL, starting with http://	url	32	<a href="#VALUE" target="_blank" rel="noopener">#VALUE</a>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	publication	citation	https://schema.org/distribution
-	notesText	Notes	Additional important information about the Dataset.		textbox	33		FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		citation
-	language	Language	Language of the Dataset		text	34		TRUE	TRUE	TRUE	TRUE	FALSE	FALSE		citation	http://purl.org/dc/terms/language
-	producer	Producer	Person or organization with the financial or administrative responsibility over this Dataset		none	35		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation
-	producerName	Name	Producer name	FamilyName, GivenName or Organization	text	36	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	TRUE	producer	citation
-	producerAffiliation	Affiliation	The organization with which the producer is affiliated.		text	37	(#VALUE)	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	producer	citation
-	producerAbbreviation	Abbreviation	The abbreviation by which the producer is commonly known. (ex. IQSS, ICPSR)		text	38	(#VALUE)	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	producer	citation
-	producerURL	URL	Producer URL points to the producer's web presence, if appropriate. Enter an absolute URL where the producer's web site is found, such as http://www.my.org.  	Enter full URL, starting with http://	url	39	<a href="#VALUE" target="_blank" rel="noopener">#VALUE</a>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	producer	citation
-	producerLogoURL	Logo URL	URL for the producer's logo, which points to this  producer's web-accessible logo image. Enter an absolute URL where the producer's logo image is found, such as http://www.my.org/images/logo.gif.	Enter full URL for image, starting with http://	url	40	<img src="#VALUE" alt="#NAME" class="metadata-logo"/><br/>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	producer	citation
-	productionDate	Production Date	Date when the data collection or other materials were produced (not distributed, published or archived).	YYYY-MM-DD	date	41		TRUE	FALSE	FALSE	TRUE	FALSE	FALSE		citation
-	productionPlace	Production Place	The location where the data collection and any other related materials were produced.		text	42		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation
-	contributor	Contributor	The organization or person responsible for either collecting, managing, or otherwise contributing in some form to the development of the resource.		none	43	:	FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	http://purl.org/dc/terms/contributor
-	contributorType	Type	The type of contributor of the  resource.  		text	44	#VALUE 	TRUE	TRUE	FALSE	TRUE	FALSE	FALSE	contributor	citation
-	contributorName	Name	The Family Name, Given Name or organization name of the contributor.	FamilyName, GivenName or Organization	text	45	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	contributor	citation
-	grantNumber	Grant Information	Grant Information		none	46	:	FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	https://schema.org/sponsor
-	grantNumberAgency	Grant Agency	Grant Number Agency		text	47	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	grantNumber	citation
-	grantNumberValue	Grant Number	The grant or contract number of the project that  sponsored the effort.		text	48	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	grantNumber	citation
-	project	Project	Information about the project as context of the data.		none	49		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	
-	projectName	Name	Name of the project.		text	50	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	project	citation
-	projectLevel	Level	The main project should get level zero. Subprojects can get higher levels.	0	int	51	(#NAME #VALUE)	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	project	citation
-	distributor	Distributor	The organization designated by the author or producer to generate copies of the particular work including any necessary editions or revisions.		none	52		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation
-	distributorName	Name	Distributor name	FamilyName, GivenName or Organization	text	53	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	distributor	citation
-	distributorAffiliation	Affiliation	The organization with which the distributor contact is affiliated.		text	54	(#VALUE)	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	distributor	citation
-	distributorAbbreviation	Abbreviation	The abbreviation by which this distributor is commonly known (e.g., IQSS, ICPSR).		text	55	(#VALUE)	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	distributor	citation
-	distributorURL	URL	Distributor URL points to the distributor's web presence, if appropriate. Enter an absolute URL where the distributor's web site is found, such as http://www.my.org.	Enter full URL, starting with http://	url	56	<a href="#VALUE" target="_blank" rel="noopener">#VALUE</a>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	distributor	citation
-	distributorLogoURL	Logo URL	URL of the distributor's logo, which points to this  distributor's web-accessible logo image. Enter an absolute URL where the distributor's logo image is found, such as http://www.my.org/images/logo.gif.	Enter full URL for image, starting with http://	url	57	<img src="#VALUE" alt="#NAME" class="metadata-logo"/><br/>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	distributor	citation
-	distributionDate	Distribution Date	Date that the work was made available for distribution/presentation.	YYYY-MM-DD	date	58		TRUE	FALSE	FALSE	TRUE	FALSE	FALSE		citation
-	depositor	Depositor	The person (Family Name, Given Name) or the name of the organization that deposited this Dataset to the repository.		text	59		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation
-	dateOfDeposit	Deposit Date	Date that the Dataset was deposited into the repository.	YYYY-MM-DD	date	60		FALSE	FALSE	FALSE	TRUE	FALSE	FALSE		citation	http://purl.org/dc/terms/dateSubmitted
-	timePeriodCovered	Time Period Covered	Time period to which the data refer. This item reflects the time period covered by the data, not the dates of coding or making documents machine-readable or the dates the data were collected. Also known as span.		none	61	;	FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	https://schema.org/temporalCoverage
-	timePeriodCoveredStart	Start	Start date which reflects the time period covered by the data, not the dates of coding or making documents machine-readable or the dates the data were collected.	YYYY-MM-DD	date	62	#NAME: #VALUE 	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	timePeriodCovered	citation
-	timePeriodCoveredEnd	End	End date which reflects the time period covered by the data, not the dates of coding or making documents machine-readable or the dates the data were collected.	YYYY-MM-DD	date	63	#NAME: #VALUE 	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	timePeriodCovered	citation
-	dateOfCollection	Date of Collection	Contains the date(s) when the data were collected.		none	64	;	FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation
-	dateOfCollectionStart	Start	Date when the data collection started.	YYYY-MM-DD	date	65	#NAME: #VALUE 	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	dateOfCollection	citation
-	dateOfCollectionEnd	End	Date when the data collection ended.	YYYY-MM-DD	date	66	#NAME: #VALUE 	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	dateOfCollection	citation
-	kindOfData	Kind of Data	Type of data included in the file: survey data, census/enumeration data, aggregate data, clinical data, event/transaction data, program source code, machine-readable text, administrative records data, experimental data, psychological test, textual data, coded textual, coded documents, time budget diaries, observation data/ratings, process-produced data, or other.		text	67		TRUE	FALSE	TRUE	TRUE	FALSE	FALSE		citation	http://rdf-vocabulary.ddialliance.org/discovery#kindOfData
-	series	Series	Information about the Dataset series.		none	68	:	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation
-	seriesName	Name	Name of the dataset series to which the Dataset belongs.		text	69	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	series	citation
-	seriesInformation	Information	History of the series and summary of those features that apply to the series as a whole.		textbox	70	#VALUE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	series	citation
-	software	Software	Information about the software used to generate the Dataset.		none	71	,	FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	https://www.w3.org/TR/prov-o/#wasGeneratedBy
-	softwareName	Name	Name of software used to generate the Dataset.		text	72	#VALUE	FALSE	TRUE	FALSE	FALSE	FALSE	FALSE	software	citation
-	softwareVersion	Version	Version of the software used to generate the Dataset.		text	73	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	software	citation
-	relatedMaterial	Related Material	Any material related to this Dataset.		textbox	74		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation
-	relatedDatasets	Related Datasets	Any Datasets that are related to this Dataset, such as previous research on this subject.		textbox	75		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	http://purl.org/dc/terms/relation
-	otherReferences	Other References	Any references that would serve as background or supporting material to this Dataset.		textbox	76		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	http://purl.org/dc/terms/references
-	dataSources	Data Sources	List of books, articles, serials, or machine-readable data files that served as the sources of the data collection.		textbox	77		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	https://www.w3.org/TR/prov-o/#wasDerivedFrom	
-	originOfSources	Origin of Sources	For historical materials, information about the origin of the sources and the rules followed in establishing the sources should be specified.		textbox	78		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation
-	characteristicOfSources	Characteristic of Sources Noted	Assessment of characteristics and source material.		textbox	79		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation
-	accessToSources	Documentation and Access to Sources	Level of documentation of the original sources.		textbox	80		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation
-	worked	Did it work?	Not only positive analyses are worthwhile to share. Negative results prevent others from doing the same mistakes.	Yes or No	text	81		TRUE	FALSE	FALSE	TRUE	FALSE	FALSE		citation
-	workedNote	Explanation	Description of your last answer. Explanation why it worked or not.		textbox	82		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation
-	storage	Storage	Information about data that could NOT be uploaded into the system.		none	83		FALSE	FALSE	TRUE	FALSE	TRUE	FALSE		citation
-	storageFile	Name	The name of the file, directory or archive.		text	84	#VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	storage	citation
-	storageLocation	Location	The dns, path or url of the location the object is stored. 		text	85	(#NAME: #VALUE)	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	storage	citation
-	storageSize	Size	The approximated size of the object. Give also Units.		text	86	[#NAME: #VALUE]	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	storage	citation
+	title	Title	The main title of the Dataset		text	0		TRUE	FALSE	FALSE	FALSE	TRUE	TRUE		citation	http://purl.org/dc/terms/title
+	subtitle	Subtitle	A secondary title that amplifies or states certain limitations on the main title		text	1		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation	
+	alternativeTitle	Alternative Title	Either 1) a title commonly used to refer to the Dataset or 2) an abbreviation of the main title		text	2		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation	http://purl.org/dc/terms/alternative
+	alternativeURL	Alternative URL	Another URL where one can view or access the data in the Dataset, e.g. a project or personal webpage	https://	url	3	<a href="#VALUE" target="_blank">#VALUE</a>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation	https://schema.org/distribution
+	otherId	Other Identifier	Another unique identifier for the Dataset (e.g. producer's or another repository's identifier)		none	4	:	FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	
+	otherIdAgency	Agency	The name of the agency that generated the other identifier		text	5	#VALUE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	otherId	citation	
+	otherIdValue	Identifier	Another identifier uniquely identifies the Dataset		text	6	#VALUE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	otherId	citation	
+	author	Author	The entity, e.g. a person or organization, that created the Dataset		none	7		FALSE	FALSE	TRUE	FALSE	TRUE	TRUE		citation	http://purl.org/dc/terms/creator
+	authorName	Name	The name of the author, such as the person's name or the name of an organization	1) Family Name, Given Name or 2) Organization XYZ	text	8	#VALUE	TRUE	FALSE	FALSE	TRUE	TRUE	TRUE	author	citation	
+	authorAffiliation	Affiliation	The name of the entity affiliated with the author, e.g. an organization's name	Organization XYZ	text	9	(#VALUE)	TRUE	FALSE	FALSE	TRUE	TRUE	FALSE	author	citation	
+	authorIdentifierScheme	Identifier Type	The type of identifier that uniquely identifies the author (e.g. ORCID, ISNI)		text	10	- #VALUE:	FALSE	TRUE	FALSE	FALSE	TRUE	FALSE	author	citation	http://purl.org/spar/datacite/AgentIdentifierScheme
+	authorIdentifier	Identifier	Uniquely identifies the author when paired with an identifier type		text	11	#VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	author	citation	http://purl.org/spar/datacite/AgentIdentifier
+	datasetContact	Point of Contact	The entity, e.g. a person or organization, that users of the Dataset can contact with questions		none	12		FALSE	FALSE	TRUE	FALSE	TRUE	TRUE		citation	
+	datasetContactName	Name	The name of the point of contact, e.g. the person's name or the name of an organization	1) FamilyName, GivenName or 2) Organization	text	13	#VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	datasetContact	citation	
+	datasetContactAffiliation	Affiliation	The name of the entity affiliated with the point of contact, e.g. an organization's name	Organization XYZ	text	14	(#VALUE)	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	datasetContact	citation	
+	datasetContactEmail	E-mail	The point of contact's email address	name@email.xyz	email	15	#EMAIL	FALSE	FALSE	FALSE	FALSE	TRUE	TRUE	datasetContact	citation	
+	dsDescription	Description	A summary describing the purpose, nature, and scope of the Dataset		none	16		FALSE	FALSE	TRUE	FALSE	TRUE	TRUE		citation	
+	dsDescriptionValue	Text	A summary describing the purpose, nature, and scope of the Dataset		textbox	17	#VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	TRUE	dsDescription	citation	
+	dsDescriptionDate	Date	The date when the description was added to the Dataset. If the Dataset contains more than one description, e.g. the data producer supplied one description and the data repository supplied another, this date is used to distinguish between the descriptions	YYYY-MM-DD	date	18	(#VALUE)	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	dsDescription	citation	
+	subject	Subject	The area of study relevant to the Dataset		text	19		TRUE	TRUE	TRUE	TRUE	TRUE	TRUE		citation	http://purl.org/dc/terms/subject
+	keyword	Keyword	A key term that describes an important aspect of the Dataset and information about any controlled vocabulary used		none	20		FALSE	FALSE	TRUE	FALSE	TRUE	FALSE		citation	
+	keywordValue	Term	A key term that describes important aspects of the Dataset		text	21	#VALUE	TRUE	FALSE	FALSE	TRUE	TRUE	FALSE	keyword	citation	
+	keywordVocabulary	Controlled Vocabulary Name	The controlled vocabulary used for the keyword term (e.g. LCSH, MeSH)		text	22	(#VALUE)	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	keyword	citation	
+	keywordVocabularyURI	Controlled Vocabulary URL	The URL where one can access information about the term's controlled vocabulary	https://	url	23	<a href="#VALUE" target="_blank" rel="noopener">#VALUE</a>	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	keyword	citation	
+	topicClassification	Topic Classification	Indicates a broad, important topic or subject that the Dataset covers and information about any controlled vocabulary used		none	24		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	
+	topicClassValue	Term	A topic or subject term		text	25	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	topicClassification	citation	
+	topicClassVocab	Controlled Vocabulary Name	The controlled vocabulary used for the keyword term (e.g. LCSH, MeSH)		text	26	(#VALUE)	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	topicClassification	citation	
+	topicClassVocabURI	Controlled Vocabulary URL	The URL where one can access information about the term's controlled vocabulary	https://	url	27	<a href="#VALUE" target="_blank" rel="noopener">#VALUE</a>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	topicClassification	citation	
+	publication	Related Publication	The article or report that uses the data in the Dataset. The full list of related publications will be displayed on the metadata tab		none	28		FALSE	FALSE	TRUE	FALSE	TRUE	FALSE		citation	http://purl.org/dc/terms/isReferencedBy
+	publicationCitation	Citation	The full bibliographic citation for the related publication		textbox	29	#VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	publication	citation	http://purl.org/dc/terms/bibliographicCitation
+	publicationIDType	Identifier Type	The type of identifier that uniquely identifies a related publication		text	30	#VALUE: 	TRUE	TRUE	FALSE	FALSE	TRUE	FALSE	publication	citation	http://purl.org/spar/datacite/ResourceIdentifierScheme
+	publicationIDNumber	Identifier	The identifier for a related publication		text	31	#VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	publication	citation	http://purl.org/spar/datacite/ResourceIdentifier
+	publicationURL	URL	The URL form of the identifier entered in the Identifier field, e.g. the DOI URL if a DOI was entered in the Identifier field. Used to display what was entered in the ID Type and ID Number fields as a link. If what was entered in the Identifier field has no URL form, the URL of the publication webpage is used, e.g. a journal article webpage	https://	url	32	<a href="#VALUE" target="_blank" rel="noopener">#VALUE</a>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	publication	citation	https://schema.org/distribution
+	notesText	Notes	Additional information about the Dataset		textbox	33		FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		citation	
+	language	Language	A language that the Dataset's files is written in		text	34		TRUE	TRUE	TRUE	TRUE	FALSE	FALSE		citation	http://purl.org/dc/terms/language
+	producer	Producer	The entity, such a person or organization, managing the finances or other administrative processes involved in the creation of the Dataset		none	35		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	
+	producerName	Name	The name of the entity, e.g. the person's name or the name of an organization	1) FamilyName, GivenName or 2) Organization	text	36	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	TRUE	producer	citation	
+	producerAffiliation	Affiliation	The name of the entity affiliated with the producer, e.g. an organization's name	Organization XYZ	text	37	(#VALUE)	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	producer	citation	
+	producerAbbreviation	Abbreviated Name	The producer's abbreviated name (e.g. IQSS, ICPSR)		text	38	(#VALUE)	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	producer	citation	
+	producerURL	URL	The URL of the producer's website	https://	url	39	<a href="#VALUE" target="_blank" rel="noopener">#VALUE</a>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	producer	citation	
+	producerLogoURL	Logo URL	The URL of the producer's logo	https://	url	40	<img src="#VALUE" alt="#NAME" class="metadata-logo"/><br/>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	producer	citation	
+	productionDate	Production Date	The date when the data were produced (not distributed, published, or archived)	YYYY-MM-DD	date	41		TRUE	FALSE	FALSE	TRUE	FALSE	FALSE		citation	
+	productionPlace	Production Location	The location where the data and any related materials were produced or collected		text	42		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation	
+	contributor	Contributor	The entity, such as a person or organization, responsible for collecting, managing, or otherwise contributing to the development of the Dataset		none	43	:	FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	http://purl.org/dc/terms/contributor
+	contributorType	Type	Indicates the type of contribution made to the dataset		text	44	#VALUE 	TRUE	TRUE	FALSE	TRUE	FALSE	FALSE	contributor	citation	
+	contributorName	Name	The name of the contributor, e.g. the person's name or the name of an organization	1) FamilyName, GivenName or 2) Organization	text	45	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	contributor	citation	
+	grantNumber	Funding Information	Information about the Dataset's financial support		none	46	:	FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	https://schema.org/sponsor
+	grantNumberAgency	Agency	The agency that provided financial support for the Dataset	Organization XYZ	text	47	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	grantNumber	citation	
+	grantNumberValue	Identifier	The grant identifier or contract identifier of the agency that provided financial support for the Dataset		text	48	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	grantNumber	citation	
+	project	Project	Information about the project as context of the data		none	49		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	
+	projectName	Name	Name of the project		text	50	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	project	citation
+	projectLevel	Level	The main project should get level zero, subprojects can get higher levels	0	int	51	(#NAME #VALUE)	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	project	citation
+	distributor	Distributor	The entity, such as a person or organization, designated to generate copies of the Dataset, including any editions or revisions		none	52		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	
+	distributorName	Name	The name of the entity, e.g. the person's name or the name of an organization	1) FamilyName, GivenName or 2) Organization	text	53	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	distributor	citation	
+	distributorAffiliation	Affiliation	The name of the entity affiliated with the distributor, e.g. an organization's name	Organization XYZ	text	54	(#VALUE)	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	distributor	citation	
+	distributorAbbreviation	Abbreviated Name	The distributor's abbreviated name (e.g. IQSS, ICPSR)		text	55	(#VALUE)	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	distributor	citation	
+	distributorURL	URL	The URL of the distributor's webpage	https://	url	56	<a href="#VALUE" target="_blank" rel="noopener">#VALUE</a>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	distributor	citation	
+	distributorLogoURL	Logo URL	The URL of the distributor's logo image, used to show the image on the Dataset's page	https://	url	57	<img src="#VALUE" alt="#NAME" class="metadata-logo"/><br/>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	distributor	citation	
+	distributionDate	Distribution Date	The date when the Dataset was made available for distribution/presentation	YYYY-MM-DD	date	58		TRUE	FALSE	FALSE	TRUE	FALSE	FALSE		citation	
+	depositor	Depositor	The entity, such as a person or organization, that deposited the Dataset in the repository	1) FamilyName, GivenName or 2) Organization	text	59		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation	
+	dateOfDeposit	Deposit Date	The date when the Dataset was deposited into the repository	YYYY-MM-DD	date	60		FALSE	FALSE	FALSE	TRUE	FALSE	FALSE		citation	http://purl.org/dc/terms/dateSubmitted
+	timePeriodCovered	Time Period	The time period that the data refer to. Also known as span. This is the time period covered by the data, not the dates of coding, collecting data, or making documents machine-readable		none	61	;	FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	https://schema.org/temporalCoverage
+	timePeriodCoveredStart	Start Date	The start date of the time period that the data refer to	YYYY-MM-DD	date	62	#NAME: #VALUE 	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	timePeriodCovered	citation	
+	timePeriodCoveredEnd	End Date	The end date of the time period that the data refer to	YYYY-MM-DD	date	63	#NAME: #VALUE 	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	timePeriodCovered	citation	
+	dateOfCollection	Date of Collection	The dates when the data were collected or generated		none	64	;	FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	
+	dateOfCollectionStart	Start Date	The date when the data collection started	YYYY-MM-DD	date	65	#NAME: #VALUE 	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	dateOfCollection	citation	
+	dateOfCollectionEnd	End Date	The date when the data collection ended	YYYY-MM-DD	date	66	#NAME: #VALUE 	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	dateOfCollection	citation	
+	kindOfData	Data Type	The type of data included in the files (e.g. survey data, clinical data, or machine-readable text)		text	67		TRUE	FALSE	TRUE	TRUE	FALSE	FALSE		citation	http://rdf-vocabulary.ddialliance.org/discovery#kindOfData
+	series	Series	Information about the dataset series to which the Dataset belong		none	68	:	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation	
+	seriesName	Name	The name of the dataset series		text	69	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	series	citation	
+	seriesInformation	Information	Can include 1) a history of the series and 2) a summary of features that apply to the series		textbox	70	#VALUE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	series	citation	
+	software	Software	Information about the software used to generate the Dataset		none	71	,	FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	https://www.w3.org/TR/prov-o/#wasGeneratedBy
+	softwareName	Name	The name of software used to generate the Dataset		text	72	#VALUE	FALSE	TRUE	FALSE	FALSE	FALSE	FALSE	software	citation	
+	softwareVersion	Version	The version of the software used to generate the Dataset, e.g. 4.11		text	73	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	software	citation	
+	relatedMaterial	Related Material	Information, such as a persistent ID or citation, about the material related to the Dataset, such as appendices or sampling information available outside of the Dataset		textbox	74		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	
+	relatedDatasets	Related Dataset	Information, such as a persistent ID or citation, about a related dataset, such as previous research on the Dataset's subject		textbox	75		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	http://purl.org/dc/terms/relation
+	otherReferences	Other Reference	Information, such as a persistent ID or citation, about another type of resource that provides background or supporting material to the Dataset		text	76		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	http://purl.org/dc/terms/references
+	dataSources	Data Source	Information, such as a persistent ID or citation, about sources of the Dataset (e.g. a book, article, serial, or machine-readable data file)		textbox	77		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	https://www.w3.org/TR/prov-o/#wasDerivedFrom
+	originOfSources	Origin of Historical Sources	For historical sources, the origin and any rules followed in establishing them as sources		textbox	78		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation	
+	characteristicOfSources	Characteristic of Sources	Characteristics not already noted elsewhere		textbox	79		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation	
+	accessToSources	Documentation and Access to Sources	1) Methods or procedures for accessing data sources and 2) any special permissions needed for access		textbox	80		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation	
+	worked	Did it work?	Not only positive analyses are worthwhile to share, negative results prevent others from doing the same mistakes	Yes or No	text	81		TRUE	FALSE	FALSE	TRUE	FALSE	FALSE		citation
+	workedNote	Explanation	Description of your last answer; explanation why it worked or not		textbox	82		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation
+	storage	Storage	Information about data that could NOT be uploaded into the system		none	83		FALSE	FALSE	TRUE	FALSE	TRUE	FALSE		citation
+	storageFile	Name	The name of the file, directory or archive		text	84	#VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	storage	citation
+	storageLocation	Location	The dns, path or url of the location the object is stored 		text	85	(#NAME: #VALUE)	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	storage	citation
+	storageSize	Size	The approximated size (with units) of the object		text	86	[#NAME: #VALUE]	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	storage	citation
 #controlledVocabulary	DatasetField	Value	identifier	displayOrder											
 	subject	Agricultural Sciences	D01	0											
 	subject	Arts and Humanities	D0	1											
@@ -120,6 +120,7 @@
 	publicationIDType	upc		14											
 	publicationIDType	url		15											
 	publicationIDType	urn		16											
+	publicationIDType	DASH-NRS		17											
 	contributorType	Data Collector		0											
 	contributorType	Data Curator		1											
 	contributorType	Data Manager		2											
@@ -146,188 +147,188 @@
 	authorIdentifierScheme	ResearcherID		6
 	authorIdentifierScheme	ScopusID		7
 	language	Abkhaz		0
-	language	Afar		1	aar
-	language	Afrikaans		2	afr
-	language	Akan		3	aka
-	language	Albanian		4	sqi
-	language	Amharic		5	amh
-	language	Arabic		6	ara
-	language	Aragonese		7	arg
-	language	Armenian		8	hye
-	language	Assamese		9	asm
-	language	Avaric		10	ava
-	language	Avestan		11	ave
-	language	Aymara		12	aym
-	language	Azerbaijani		13	aze
-	language	Bambara		14	bam
-	language	Bashkir		15	bak
-	language	Basque		16	eus
-	language	Belarusian		17	bel
-	language	Bengali, Bangla		18											
-	language	Bihari		19											
-	language	Bislama		20	bis
-	language	Bosnian		21	bos
-	language	Breton		22	bre
-	language	Bulgarian		23	bul
-	language	Burmese		24	mya
-	language	Catalan,Valencian		25											
-	language	Chamorro		26	cha
-	language	Chechen		27	che
-	language	Chichewa, Chewa, Nyanja		28											
-	language	Chinese		29	zho
-	language	Chuvash		30	chv
-	language	Cornish		31	cor
-	language	Corsican		32	cos
-	language	Cree		33	cre
-	language	Croatian		34	hrv
-	language	Czech		35	ces
-	language	Danish		36	dan
-	language	Divehi, Dhivehi, Maldivian		37											
-	language	Dutch		38	nld
-	language	Dzongkha		39	dzo
-	language	English		40	eng
-	language	Esperanto		41	epo
-	language	Estonian		42	est
-	language	Ewe		43	ewe
-	language	Faroese		44	fao
-	language	Fijian		45	fij
-	language	Finnish		46	fin
-	language	French		47	fra
-	language	Fula, Fulah, Pulaar, Pular		48											
-	language	Galician		49	glg
-	language	Georgian		50	kat
-	language	German		51	deu
-	language	Greek (modern)		52											
-	language	Guaraní		53											
-	language	Gujarati		54	guj
-	language	Haitian, Haitian Creole		55											
-	language	Hausa		56	hau
-	language	Hebrew (modern)		57											
-	language	Herero		58	her
-	language	Hindi		59	hin
-	language	Hiri Motu		60	hmo
-	language	Hungarian		61	hun
-	language	Interlingua		62											
-	language	Indonesian		63	ind
-	language	Interlingue		64	ile
-	language	Irish		65	gle
-	language	Igbo		66	ibo
-	language	Inupiaq		67	ipk
-	language	Ido		68	ido
-	language	Icelandic		69	isl
-	language	Italian		70	ita
-	language	Inuktitut		71	iku
-	language	Japanese		72	jpn
-	language	Javanese		73	jav
-	language	Kalaallisut, Greenlandic		74											
-	language	Kannada		75	kan
-	language	Kanuri		76	kau
-	language	Kashmiri		77	kas
-	language	Kazakh		78	kaz
-	language	Khmer		79	khm
-	language	Kikuyu, Gikuyu		80											
-	language	Kinyarwanda		81	kin
+	language	Afar		1	aar	aa
+	language	Afrikaans		2	afr	af
+	language	Akan		3	aka	ak
+	language	Albanian		4	sqi	alb	sq
+	language	Amharic		5	amh	am
+	language	Arabic		6	ara	ar
+	language	Aragonese		7	arg	an
+	language	Armenian		8	hye	arm	hy
+	language	Assamese		9	asm	as
+	language	Avaric		10	ava	av
+	language	Avestan		11	ave	ae
+	language	Aymara		12	aym	ay
+	language	Azerbaijani		13	aze	az
+	language	Bambara		14	bam	bm
+	language	Bashkir		15	bak	ba
+	language	Basque		16	eus	baq	eu
+	language	Belarusian		17	bel	be
+	language	Bengali, Bangla		18	ben	bn
+	language	Bihari		19	bih	bh
+	language	Bislama		20	bis	bi
+	language	Bosnian		21	bos	bs
+	language	Breton		22	bre	br
+	language	Bulgarian		23	bul	bg
+	language	Burmese		24	mya	bur	my
+	language	Catalan,Valencian		25	cat ca
+	language	Chamorro		26	cha	ch
+	language	Chechen		27	che	ce
+	language	Chichewa, Chewa, Nyanja		28	nya	ny
+	language	Chinese		29	zho	chi	zh
+	language	Chuvash		30	chv	cv
+	language	Cornish		31	cor	kw
+	language	Corsican		32	cos	co
+	language	Cree		33	cre	cr
+	language	Croatian		34	hrv	src	hr
+	language	Czech		35	ces	cze	cs
+	language	Danish		36	dan	da
+	language	Divehi, Dhivehi, Maldivian		37	div	dv
+	language	Dutch		38	nld	dut	nl
+	language	Dzongkha		39	dzo	dz
+	language	English		40	eng	en
+	language	Esperanto		41	epo	eo
+	language	Estonian		42	est	et
+	language	Ewe		43	ewe	ee
+	language	Faroese		44	fao	fo
+	language	Fijian		45	fij	fj
+	language	Finnish		46	fin	fi
+	language	French		47	fra	fre	fr
+	language	Fula, Fulah, Pulaar, Pular		48	ful	ff
+	language	Galician		49	glg	gl
+	language	Georgian		50	kat	geo	ka
+	language	German		51	deu	ger	de
+	language	Greek (modern)		52	gre	ell	el
+	language	Guaraní		53	grn	gn
+	language	Gujarati		54	guj	gu
+	language	Haitian, Haitian Creole		55	hat ht
+	language	Hausa		56	hau	ha
+	language	Hebrew (modern)		57	heb	he
+	language	Herero		58	her	hz
+	language	Hindi		59	hin	hi
+	language	Hiri Motu		60	hmo	ho
+	language	Hungarian		61	hun	hu
+	language	Interlingua		62	ina	ia
+	language	Indonesian		63	ind	id
+	language	Interlingue		64	ile	ie
+	language	Irish		65	gle	ga
+	language	Igbo		66	ibo	ig
+	language	Inupiaq		67	ipk	ik
+	language	Ido		68	ido	io
+	language	Icelandic		69	isl	ice	is
+	language	Italian		70	ita	it
+	language	Inuktitut		71	iku	iu
+	language	Japanese		72	jpn	ja
+	language	Javanese		73	jav	jv
+	language	Kalaallisut, Greenlandic		74	kal	kl
+	language	Kannada		75	kan	kn
+	language	Kanuri		76	kau	kr
+	language	Kashmiri		77	kas	ks
+	language	Kazakh		78	kaz	kk
+	language	Khmer		79	khm	km
+	language	Kikuyu, Gikuyu		80	kik	ki
+	language	Kinyarwanda		81	kin	rw
 	language	Kyrgyz		82											
-	language	Komi		83	kom
-	language	Kongo		84	kon
-	language	Korean		85	kor
-	language	Kurdish		86	kur
-	language	Kwanyama, Kuanyama		87											
-	language	Latin		88	lat
-	language	Luxembourgish, Letzeburgesch		89											
-	language	Ganda		90	lug
-	language	Limburgish, Limburgan, Limburger		91											
-	language	Lingala		92	lin
-	language	Lao		93	lao
-	language	Lithuanian		94	lit
-	language	Luba-Katanga		95	lub
-	language	Latvian		96	lav
-	language	Manx		97	glv
-	language	Macedonian		98	mkd
-	language	Malagasy		99	mlg
-	language	Malay		100											
-	language	Malayalam		101	mal
-	language	Maltese		102	mlt
-	language	Māori		103											
-	language	Marathi (Marāṭhī)		104											
-	language	Marshallese		105	mah
+	language	Komi		83	kom	kv
+	language	Kongo		84	kon	kg
+	language	Korean		85	kor	ko
+	language	Kurdish		86	kur	ku
+	language	Kwanyama, Kuanyama		87	kua	kj
+	language	Latin		88	lat	la
+	language	Luxembourgish, Letzeburgesch		89	ltz	lb
+	language	Ganda		90	lug	lg
+	language	Limburgish, Limburgan, Limburger		91	lim	li
+	language	Lingala		92	lin	ln
+	language	Lao		93	lao	lo
+	language	Lithuanian		94	lit	lt
+	language	Luba-Katanga		95	lub	lu
+	language	Latvian		96	lav	lv
+	language	Manx		97	glv	gv
+	language	Macedonian		98	mkd	mac	mk
+	language	Malagasy		99	mlg	mg
+	language	Malay		100	may	msa	ms
+	language	Malayalam		101	mal	ml
+	language	Maltese		102	mlt	mt
+	language	Māori		103	mao	mri	mi
+	language	Marathi (Marāṭhī)		104	mar	mr
+	language	Marshallese		105	mah	mh
 	language	Mixtepec Mixtec		106	mix
-	language	Mongolian		107	mon
-	language	Nauru		108	nau
-	language	Navajo, Navaho		109											
-	language	Northern Ndebele		110											
-	language	Nepali		111											
-	language	Ndonga		112	ndo
-	language	Norwegian Bokmål		113	nob
-	language	Norwegian Nynorsk		114	nno
-	language	Norwegian		115	nor
+	language	Mongolian		107	mon	mn
+	language	Nauru		108	nau	na
+	language	Navajo, Navaho		109	nav	nv
+	language	Northern Ndebele		110	nde	nd
+	language	Nepali		111	nep	ne
+	language	Ndonga		112	ndo	ng
+	language	Norwegian Bokmål		113	nob	nb
+	language	Norwegian Nynorsk		114	nno	nn
+	language	Norwegian		115	nor	no
 	language	Nuosu		116											
-	language	Southern Ndebele		117											
-	language	Occitan		118											
-	language	Ojibwe, Ojibwa		119											
-	language	Old Church Slavonic,Church Slavonic,Old Bulgarian		120											
-	language	Oromo		121	orm
-	language	Oriya		122											
-	language	Ossetian, Ossetic		123											
-	language	Panjabi, Punjabi		124											
-	language	Pāli		125											
-	language	Persian (Farsi)		126											
-	language	Polish		127	pol
-	language	Pashto, Pushto		128											
-	language	Portuguese		129	por
-	language	Quechua		130	que
-	language	Romansh		131	roh
-	language	Kirundi		132											
-	language	Romanian		133	ron
-	language	Russian		134	rus
-	language	Sanskrit (Saṁskṛta)		135											
-	language	Sardinian		136	srd
-	language	Sindhi		137	snd
-	language	Northern Sami		138	sme
-	language	Samoan		139	smo
-	language	Sango		140	sag
-	language	Serbian		141	srp
-	language	Scottish Gaelic, Gaelic		142											
-	language	Shona		143	sna
-	language	Sinhala, Sinhalese		144											
-	language	Slovak		145	slk
-	language	Slovene		146											
-	language	Somali		147	som
-	language	Southern Sotho		148	sot
-	language	Spanish, Castilian		149											
-	language	Sundanese		150	sun
-	language	Swahili		151											
-	language	Swati		152	ssw
-	language	Swedish		153	swe
-	language	Tamil		154	tam
-	language	Telugu		155	tel
-	language	Tajik		156	tgk
-	language	Thai		157	tha
-	language	Tigrinya		158	tir
-	language	Tibetan Standard, Tibetan, Central		159											
-	language	Turkmen		160	tuk
-	language	Tagalog		161	tgl
-	language	Tswana		162	tsn
-	language	Tonga (Tonga Islands)		163	ton
-	language	Turkish		164	tur
-	language	Tsonga		165	tso
-	language	Tatar		166	tat
-	language	Twi		167	twi
-	language	Tahitian		168	tah
-	language	Uyghur, Uighur		169											
-	language	Ukrainian		170	ukr
-	language	Urdu		171	urd
-	language	Uzbek		172	uzb
-	language	Venda		173	ven
-	language	Vietnamese		174	vie
-	language	Volapük		175	vol
-	language	Walloon		176	wln
-	language	Welsh		177	cym
-	language	Wolof		178	wol
-	language	Western Frisian		179	fry
-	language	Xhosa		180	xho
-	language	Yiddish		181	yid
-	language	Yoruba		182	yor
-	language	Zhuang, Chuang		183											
-	language	Zulu		184	zul
-	language	Not applicable		185																						
+	language	Southern Ndebele		117	nbl	nr
+	language	Occitan		118	oci	oc
+	language	Ojibwe, Ojibwa		119	oji	oj
+	language	Old Church Slavonic,Church Slavonic,Old Bulgarian		120	chu	cu
+	language	Oromo		121	orm	om
+	language	Oriya		122	ori	or
+	language	Ossetian, Ossetic		123	oss	os
+	language	Panjabi, Punjabi		124	pan	pa
+	language	Pāli		125	pli	pi
+	language	Persian (Farsi)		126	per	fas	fa
+	language	Polish		127	pol	pl
+	language	Pashto, Pushto		128	pus	ps
+	language	Portuguese		129	por	pt
+	language	Quechua		130	que	qu
+	language	Romansh		131	roh	rm
+	language	Kirundi		132	run	rn
+	language	Romanian		133	ron	rum	ro
+	language	Russian		134	rus	ru
+	language	Sanskrit (Saṁskṛta)		135	san	sa
+	language	Sardinian		136	srd	sc
+	language	Sindhi		137	snd	sd
+	language	Northern Sami		138	sme	se
+	language	Samoan		139	smo	sm
+	language	Sango		140	sag	sg
+	language	Serbian		141	srp	scc	sr
+	language	Scottish Gaelic, Gaelic		142	gla	gd
+	language	Shona		143	sna	sn
+	language	Sinhala, Sinhalese		144	sin	si
+	language	Slovak		145	slk	slo	sk
+	language	Slovene		146	slv	sl
+	language	Somali		147	som	so
+	language	Southern Sotho		148	sot	st
+	language	Spanish, Castilian		149	spa	es
+	language	Sundanese		150	sun	su
+	language	Swahili		151	swa	sw
+	language	Swati		152	ssw	ss
+	language	Swedish		153	swe	sv
+	language	Tamil		154	tam	ta
+	language	Telugu		155	tel	te
+	language	Tajik		156	tgk	tg
+	language	Thai		157	tha	th
+	language	Tigrinya		158	tir	ti
+	language	Tibetan Standard, Tibetan, Central		159	tib	bod	bo
+	language	Turkmen		160	tuk	tk
+	language	Tagalog		161	tgl	tl
+	language	Tswana		162	tsn	tn
+	language	Tonga (Tonga Islands)		163	ton	to
+	language	Turkish		164	tur	tr
+	language	Tsonga		165	tso	ts
+	language	Tatar		166	tat	tt
+	language	Twi		167	twi	tw
+	language	Tahitian		168	tah	ty
+	language	Uyghur, Uighur		169	uig	ug
+	language	Ukrainian		170	ukr	uk
+	language	Urdu		171	urd	ur
+	language	Uzbek		172	uzb	uz
+	language	Venda		173	ven	ve
+	language	Vietnamese		174	vie	vi
+	language	Volapük		175	vol	vo
+	language	Walloon		176	wln	wa
+	language	Welsh		177	cym	wel	cy
+	language	Wolof		178	wol	wo
+	language	Western Frisian		179	fry	fy
+	language	Xhosa		180	xho	xh
+	language	Yiddish		181	yid	yi
+	language	Yoruba		182	yor	yo
+	language	Zhuang, Chuang		183	zha	za
+	language	Zulu		184	zul	zu
+	language	Not applicable		185											


### PR DESCRIPTION
Beside just using the upstream changes, I followed the (new) convention to remove the dot at the end of the description of each field.

Maybe we can further think of adjusting the description of keyword 'keywordVocabularyURI' / 'topicClassVocabURI', so that it matches our understanding? But I would do that in a different commit, if you agree.